### PR TITLE
feat: changed to the new branch of forked irc repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katelibby",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Kate Libby ircbot",
   "repository": {
     "type": "git",
@@ -103,7 +103,7 @@
     "entities": "1.1.1",
     "google": "2.1.0",
     "github": "13.1.0",
-    "irc": "wh-iterabb-it/node-irc#master",
+    "irc": "wh-iterabb-it/node-irc#development",
     "read": "1.0.7",
     "request": "2.83.0",
     "mta-gtfs": "1.1.0",


### PR DESCRIPTION
There is a number of problems with `node-irc`, I have since forked it and made some dirty changes to the code. I hope this is the last release which will use `node-irc`, as its become too burdensome to maintain both repos for a simple bot. 

