### PR TITLE
feat: added days to about/format

### DIFF
--- a/commands/about.js
+++ b/commands/about.js
@@ -1,5 +1,5 @@
 import pkjson from '../package.json';
-import toHHMMSS from '../utils/format';
+import format from '../utils/format';
 import config from '../helpers/config_helper';
 import BaseCommand from './utils/command_factory';
 
@@ -16,7 +16,7 @@ const AboutCommand = function AboutCommand() {
   return Object.assign(Object.create(basedCommand), {
     primary: (args) => {
       const time = process.uptime();
-      const uptime = toHHMMSS(time + '');
+      const uptime = format.toDDHHMMSS(time + '');
       const response = `About this Bot\r\nVersion: ${pkjson.version}\r\nTotal Uptime of Bot: ${uptime}`;
       return Promise.resolve(response);
     },

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -10,34 +10,72 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 describe('Format Utility Tests', () => {
+  describe('toDDHHMMSS method', () => {
+    it('should return 1 second when 1 seconds passed in', () => {
+      const expected = '00:00:00:01';
+      const resp = format.toDDHHMMSS(1);
+      expect(resp).to.equal(expected);
+    });
+
+    it('should return 1 minute when 60 seconds passed in', () => {
+      const expected = '00:00:01:00';
+      const resp = format.toDDHHMMSS(60);
+      expect(resp).to.equal(expected);
+    });
+
+    it('should return 1 hour when 3600 seconds passed in', () => {
+      const expected = '00:01:00:00';
+      const resp = format.toDDHHMMSS(3600);
+      expect(resp).to.equal(expected);
+    });
+
+    it('should return 1 day when 86400 seconds passed in', () => {
+      const expected = '01:00:00:00';
+      const resp = format.toDDHHMMSS(86400);
+      expect(resp).to.equal(expected);
+    });
+
+    it('should return 0 when 0 seconds passed in', () => {
+      const expected = '00:00:00:00';
+      const resp = format.toDDHHMMSS(0);
+      expect(resp).to.equal(expected);
+    });
+
+    it('should return 1 day 1 hour 1 minute 6 seconds when 90066 seconds passed in', () => {
+      const expected = '01:01:01:06';
+      const resp = format.toDDHHMMSS(90066);
+      expect(resp).to.equal(expected);
+    });
+  });
+
   describe('toHHMMSS method', () => {
     it('should return 1 second when 1 seconds passed in', () => {
       const expected = '00:00:01';
-      const resp = format(1);
+      const resp = format.toHHMMSS(1);
       expect(resp).to.equal(expected);
     });
 
     it('should return 1 minute when 60 seconds passed in', () => {
       const expected = '00:01:00';
-      const resp = format(60);
+      const resp = format.toHHMMSS(60);
       expect(resp).to.equal(expected);
     });
 
     it('should return 1 hour when 3600 seconds passed in', () => {
       const expected = '01:00:00';
-      const resp = format(3600);
+      const resp = format.toHHMMSS(3600);
       expect(resp).to.equal(expected);
     });
 
     it('should return 0 when 0 seconds passed in', () => {
       const expected = '00:00:00';
-      const resp = format(0);
+      const resp = format.toHHMMSS(0);
       expect(resp).to.equal(expected);
     });
 
     it('should return 0 when 0 seconds passed in', () => {
       const expected = '01:01:06';
-      const resp = format(3666);
+      const resp = format.toHHMMSS(3666);
       expect(resp).to.equal(expected);
     });
   });

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,10 +1,41 @@
 /**
  * toHHMMSS
+ * turns an amount of seconds into days, hours, minutes seconds
+ * @param {int} inctime - an amount of seconds to be formatted
+ * @return {string} 'dd:hh:mm:ss' days, hours, minutes seconds returned as a string
+ */
+function toDDHHMMSS(inctime) {
+  let secNum = parseInt(inctime, 10);
+
+  const minSec = 60;
+  const hourSec = 3600;
+  const daySec = 86400;
+
+  let days = Math.floor(secNum / daySec);
+  secNum -= days * daySec;
+  let hours = Math.floor(secNum / hourSec);
+  secNum -= hours * hourSec;
+  let minutes = Math.floor(secNum  / minSec);
+  secNum -= minutes * minSec;
+  let seconds = secNum;
+
+  if (days < 10) { days = '0' + days; }
+  if (hours < 10) { hours = '0' + hours; }
+  if (minutes < 10) { minutes = '0' + minutes; }
+  if (seconds < 10) { seconds = '0' + seconds; }
+
+  const time = `${days}:${hours}:${minutes}:${seconds}`;
+
+  return time;
+}
+
+/**
+ * toHHMMSS
  * turns an amount of seconds into hours, minutes seconds
  * @param {int} inctime - an amount of seconds to be formatted
  * @return {string} 'hh:mm:ss' hours, minutes seconds returned as a string
  */
-export default function toHHMMSS(inctime) {
+function toHHMMSS(inctime) {
   const secNum = parseInt(inctime, 10);
 
   let hours = Math.floor(secNum / 3600);
@@ -18,3 +49,5 @@ export default function toHHMMSS(inctime) {
 
   return time;
 }
+
+export default {toHHMMSS, toDDHHMMSS}


### PR DESCRIPTION
### Description

changing the output of the `!about` command:
#### Before: 
```
About this Bot
Version: 1.0.2
Total Uptime of Bot: 228:28:05
```
#### After: 
```
About this Bot
Version: 1.0.2
Total Uptime of Bot: 09:12:28:05
```
The new format is DD:HH:MM:DD as long number of hours is hard to translate into weeks months ect