### PR TITLE
feat: added lirr trains

### DIFF
--- a/commands/trainstatus.js
+++ b/commands/trainstatus.js
@@ -8,7 +8,7 @@ import BaseCommand from './utils/command_factory';
 
 const factoryParams = {
   enabled: true,
-  help_msg: `Check the status of your NYC Metro Line!\r\nSyntax is ${config.commandChar}mtastatus { line }`,
+  help_msg: `Check the status of your LIRR or NYC Metro Line!\r\nSyntax is ${config.commandChar}trainstatus { line }`,
   alias: false,
   nsfw: false,
 };
@@ -55,11 +55,34 @@ class MTA {
         return 'S';
       case 'SIR':
         return 'SIR';
+
+      case 'BABYLON':
+        return 'Babylon';
+      case 'CITY TERMINAL ZONE':
+        return 'City Terminal Zone';
+      case 'FAR ROCKAWAY':
+        return 'Far Rockaway';
+      case 'HEMPSTEAD':
+        return 'Hempstead';
+      case 'LONG BEACH':
+        return 'Long Beach';
+      case 'MONTUAK':
+        return 'Montauk';
+      case 'OYSTER BAY':
+        return 'Oyster Bay';
+      case 'PORT JEFFERSON':
+        return 'Port Jefferson';
+      case 'PORT WASHINGTON':
+        return 'Port Washington';
+      case 'RONKONKOMA':
+        return 'Ronkonkoma';
+      case 'WEST HEMPSTEAD':
+        return 'West Hempstead';
       default:
         return null;
     }
   }
-  
+
   /**
    * getColorForLine
    * @param {string} input - returns the color for the line, this is normally used for IRC coloring
@@ -98,20 +121,38 @@ const MtastatusCommand = function MtastatusCommand() {
       if (!MTA.getLineKey(args)) {
         return Promise.resolve('You must specify a valid line!');
       }
-      await mta.status('subway').then((subway) => {
-        const lineName = MTA.getLineKey(args);
-        subway.map((currentLine) => {
-          if (currentLine.name === lineName) {
-            let outStatus = Sanitize.sanitize(currentLine.name) + ': ' +
-              Sanitize.sanitize(striptags(currentLine.status));
-            let outText = Sanitize.sanitize(striptags(currentLine.text));
-            if (outText.length > 0) {
-              outStatus = outStatus + outText.replace(/\s+/g, ' ');
+      if (args.length > 4) {
+        await mta.status('LIRR').then((train) => {
+          const lineName = MTA.getLineKey(args);
+          console.log(train);
+          train.map((currentLine) => {
+            if (currentLine.name === lineName) {
+              let outStatus = Sanitize.sanitize(currentLine.name) + ': ' +
+                Sanitize.sanitize(striptags(currentLine.status));
+              let outText = Sanitize.sanitize(striptags(currentLine.text));
+              if (outText.length > 0) {
+                outStatus = outStatus + outText.replace(/\s+/g, ' ');
+              }
+              response = outStatus;
             }
-            response = outStatus;
-          }
+          });
         });
-      });
+      } else {
+        await mta.status('subway').then((subway) => {
+          const lineName = MTA.getLineKey(args);
+          subway.map((currentLine) => {
+            if (currentLine.name === lineName) {
+              let outStatus = Sanitize.sanitize(currentLine.name) + ': ' +
+                Sanitize.sanitize(striptags(currentLine.status));
+              let outText = Sanitize.sanitize(striptags(currentLine.text));
+              if (outText.length > 0) {
+                outStatus = outStatus + outText.replace(/\s+/g, ' ');
+              }
+              response = outStatus;
+            }
+          });
+        });
+      }
       return Promise.resolve(response);
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katelibby",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "An IRC and Slack Bot",
   "repository": {
     "type": "git",

--- a/test/commands/trainstatus.test.js
+++ b/test/commands/trainstatus.test.js
@@ -10,7 +10,7 @@ const { expect } = chai;
 describe('Command', () => {
   describe('trainstatus', () => {
     describe('main', () => {
-      const expectedHelp = `Check the status of your NYC Metro Line!\r\nSyntax is ${config.commandChar}trainstatus { line }`;
+      const expectedHelp = `Check the status of your LIRR or NYC Metro Line!\r\nSyntax is ${config.commandChar}trainstatus { line }`;
 
       it('should return expected help result when passed in "help"', (done) => {
         try {

--- a/test/commands/trainstatus.test.js
+++ b/test/commands/trainstatus.test.js
@@ -2,19 +2,19 @@ import chai from 'chai';
 import sinon from 'sinon';
 
 import commands from '../../commands/';
-import MTA from '../../commands/mtastatus';
+import MTA from '../../commands/trainstatus';
 import config from '../../helpers/config_helper';
 
 const { expect } = chai;
 
 describe('Command', () => {
-  describe('Mtastatus', () => {
+  describe('trainstatus', () => {
     describe('main', () => {
-      const expectedHelp = `Check the status of your NYC Metro Line!\r\nSyntax is ${config.commandChar}mtastatus { line }`;
+      const expectedHelp = `Check the status of your NYC Metro Line!\r\nSyntax is ${config.commandChar}trainstatus { line }`;
 
       it('should return expected help result when passed in "help"', (done) => {
         try {
-          commands.mtastatus.main('help').then((result) => {
+          commands.trainstatus.main('help').then((result) => {
             expect(result).to.equal(expectedHelp);
             done();
           });
@@ -39,7 +39,7 @@ describe('Command', () => {
 
       it('should return expected error result when passed in an invalid line', (done) => {
         try {
-          commands.mtastatus.main('tacobell').then((result) => {
+          commands.trainstatus.main('tacobell').then((result) => {
             expect(result).to.equal('You must specify a valid line!');
             done();
           });
@@ -51,177 +51,177 @@ describe('Command', () => {
 
     describe('getColorForLine', () => {
       it('should return expected transit line result "light_red" when passed in "123" in various forms', () => {
-          const resultValid = commands.mtastatus.colorForLine('123')
+          const resultValid = commands.trainstatus.colorForLine('123')
           expect(resultValid).to.equal('light_red');
       });
 
       it('should return expected transit line result null when passed in invalid data', () => {
-          const resultInvalid = commands.mtastatus.colorForLine('tacobell')
+          const resultInvalid = commands.trainstatus.colorForLine('tacobell')
           expect(resultInvalid).to.equal(null);
       });
     });
 
     describe('getLineKey', () => {
       it('should return expected transit line result "123" when passed in "1", "2", "3" in various forms', () => {
-          const resultOne = commands.mtastatus.lineKey('1')
+          const resultOne = commands.trainstatus.lineKey('1')
           expect(resultOne).to.equal('123');
 
-          const resultTwo = commands.mtastatus.lineKey('2')
+          const resultTwo = commands.trainstatus.lineKey('2')
           expect(resultTwo).to.equal('123');
 
-          const resultThree = commands.mtastatus.lineKey('3')
+          const resultThree = commands.trainstatus.lineKey('3')
           expect(resultThree).to.equal('123');
       });
 
       it('should return expected transit line result "456" when passed in "4", "5", "6" in various forms', () => {
-          const resultFour = commands.mtastatus.lineKey('4')
+          const resultFour = commands.trainstatus.lineKey('4')
           expect(resultFour).to.equal('456');
 
-          const resultFive = commands.mtastatus.lineKey('5')
+          const resultFive = commands.trainstatus.lineKey('5')
           expect(resultFive).to.equal('456');
 
-          const resultSix = commands.mtastatus.lineKey('6')
+          const resultSix = commands.trainstatus.lineKey('6')
           expect(resultSix).to.equal('456');
       });
 
       it('should return expected transit line result "7" when passed in "7" in various forms', () => {
-          const resultSeven = commands.mtastatus.lineKey('7')
+          const resultSeven = commands.trainstatus.lineKey('7')
           expect(resultSeven).to.equal('7');
       });
 
       it('should return expected transit line result "ACE" when passed in "A", "C", "E" in various forms', () => {
           const expectedLine = 'ACE';
 
-          const resultAUppercase = commands.mtastatus.lineKey('A');
+          const resultAUppercase = commands.trainstatus.lineKey('A');
           expect(resultAUppercase).to.equal(expectedLine);
 
-          const resultALowercase = commands.mtastatus.lineKey('a')
+          const resultALowercase = commands.trainstatus.lineKey('a')
           expect(resultALowercase).to.equal(expectedLine);
 
-          const resultCUppercase = commands.mtastatus.lineKey('C')
+          const resultCUppercase = commands.trainstatus.lineKey('C')
           expect(resultCUppercase).to.equal(expectedLine);
 
-          const resultCLowercase = commands.mtastatus.lineKey('c')
+          const resultCLowercase = commands.trainstatus.lineKey('c')
           expect(resultCLowercase).to.equal(expectedLine);
 
-          const resultEUppercase = commands.mtastatus.lineKey('E')
+          const resultEUppercase = commands.trainstatus.lineKey('E')
           expect(resultEUppercase).to.equal(expectedLine);
 
-          const resultELowercase = commands.mtastatus.lineKey('e')
+          const resultELowercase = commands.trainstatus.lineKey('e')
           expect(resultELowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "BDFM" when passed in "B", "D", "F", "M" in various forms', () => {
           const expectedLine = 'BDFM';
 
-          const resultBUppercase = commands.mtastatus.lineKey('B');
+          const resultBUppercase = commands.trainstatus.lineKey('B');
           expect(resultBUppercase).to.equal(expectedLine);
 
-          const resultBLowercase = commands.mtastatus.lineKey('b')
+          const resultBLowercase = commands.trainstatus.lineKey('b')
           expect(resultBLowercase).to.equal(expectedLine);
 
-          const resultDUppercase = commands.mtastatus.lineKey('D')
+          const resultDUppercase = commands.trainstatus.lineKey('D')
           expect(resultDUppercase).to.equal(expectedLine);
 
-          const resultDLowercase = commands.mtastatus.lineKey('d')
+          const resultDLowercase = commands.trainstatus.lineKey('d')
           expect(resultDLowercase).to.equal(expectedLine);
 
-          const resultFUppercase = commands.mtastatus.lineKey('F')
+          const resultFUppercase = commands.trainstatus.lineKey('F')
           expect(resultFUppercase).to.equal(expectedLine);
 
-          const resultFLowercase = commands.mtastatus.lineKey('f')
+          const resultFLowercase = commands.trainstatus.lineKey('f')
           expect(resultFLowercase).to.equal(expectedLine);
 
-          const resultMUppercase = commands.mtastatus.lineKey('M')
+          const resultMUppercase = commands.trainstatus.lineKey('M')
           expect(resultMUppercase).to.equal(expectedLine);
 
-          const resultMLowercase = commands.mtastatus.lineKey('m')
+          const resultMLowercase = commands.trainstatus.lineKey('m')
           expect(resultMLowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "G" when passed in "G" in various forms', () => {
           const expectedLine = 'G';
 
-          const resultGUppercase = commands.mtastatus.lineKey('G');
+          const resultGUppercase = commands.trainstatus.lineKey('G');
           expect(resultGUppercase).to.equal(expectedLine);
 
-          const resultGLowercase = commands.mtastatus.lineKey('g')
+          const resultGLowercase = commands.trainstatus.lineKey('g')
           expect(resultGLowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "JZ" when passed in "J" or "Z" in various forms', () => {
           const expectedLine = 'JZ';
 
-          const resultJUppercase = commands.mtastatus.lineKey('J');
+          const resultJUppercase = commands.trainstatus.lineKey('J');
           expect(resultJUppercase).to.equal(expectedLine);
 
-          const resultJLowercase = commands.mtastatus.lineKey('j')
+          const resultJLowercase = commands.trainstatus.lineKey('j')
           expect(resultJLowercase).to.equal(expectedLine);
 
-          const resultZUppercase = commands.mtastatus.lineKey('Z');
+          const resultZUppercase = commands.trainstatus.lineKey('Z');
           expect(resultZUppercase).to.equal(expectedLine);
 
-          const resultZLowercase = commands.mtastatus.lineKey('z')
+          const resultZLowercase = commands.trainstatus.lineKey('z')
           expect(resultZLowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "NQR" when passed in "N", "Q", "R" in various forms', () => {
           const expectedLine = 'NQR';
 
-          const resultNUppercase = commands.mtastatus.lineKey('N');
+          const resultNUppercase = commands.trainstatus.lineKey('N');
           expect(resultNUppercase).to.equal(expectedLine);
 
-          const resultNLowercase = commands.mtastatus.lineKey('n')
+          const resultNLowercase = commands.trainstatus.lineKey('n')
           expect(resultNLowercase).to.equal(expectedLine);
 
-          const resultQUppercase = commands.mtastatus.lineKey('Q')
+          const resultQUppercase = commands.trainstatus.lineKey('Q')
           expect(resultQUppercase).to.equal(expectedLine);
 
-          const resultQLowercase = commands.mtastatus.lineKey('q')
+          const resultQLowercase = commands.trainstatus.lineKey('q')
           expect(resultQLowercase).to.equal(expectedLine);
 
-          const resultRUppercase = commands.mtastatus.lineKey('R')
+          const resultRUppercase = commands.trainstatus.lineKey('R')
           expect(resultRUppercase).to.equal(expectedLine);
 
-          const resultRLowercase = commands.mtastatus.lineKey('r')
+          const resultRLowercase = commands.trainstatus.lineKey('r')
           expect(resultRLowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "S" when passed in "S" in various forms', () => {
           const expectedLine = 'S';
 
-          const resultSUppercase = commands.mtastatus.lineKey('S');
+          const resultSUppercase = commands.trainstatus.lineKey('S');
           expect(resultSUppercase).to.equal(expectedLine);
 
-          const resultSLowercase = commands.mtastatus.lineKey('s')
+          const resultSLowercase = commands.trainstatus.lineKey('s')
           expect(resultSLowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "L" when passed in "L" in various forms', () => {
           const expectedLine = 'L';
 
-          const resultLUppercase = commands.mtastatus.lineKey('L');
+          const resultLUppercase = commands.trainstatus.lineKey('L');
           expect(resultLUppercase).to.equal(expectedLine);
 
-          const resultLLowercase = commands.mtastatus.lineKey('l')
+          const resultLLowercase = commands.trainstatus.lineKey('l')
           expect(resultLLowercase).to.equal(expectedLine);
       });
 
       it('should return expected transit line result "SIR" when passed in "SIR" in various forms', () => {
           const expectedLine = 'SIR';
 
-          const resultSIRUppercase = commands.mtastatus.lineKey('SIR');
+          const resultSIRUppercase = commands.trainstatus.lineKey('SIR');
           expect(resultSIRUppercase).to.equal(expectedLine);
 
-          const resultSIRLowercase = commands.mtastatus.lineKey('sir')
+          const resultSIRLowercase = commands.trainstatus.lineKey('sir')
           expect(resultSIRLowercase).to.equal(expectedLine);
 
-          const resultSIRMixedcase = commands.mtastatus.lineKey('sIR')
+          const resultSIRMixedcase = commands.trainstatus.lineKey('sIR')
           expect(resultSIRMixedcase).to.equal(expectedLine);
       });
 
       it('should return expected null value for malformed transit line', () => {
-          const result = commands.mtastatus.lineKey('tacobell')
+          const result = commands.trainstatus.lineKey('tacobell')
           expect(result).to.equal(null);
       });
     });


### PR DESCRIPTION
### Description https://github.com/wh-iterabb-it/katelibby/issues/300
 * adds `LIRR` trains to the command 
 * renames command from `mtastatus` to `trainstatus`
 * Accepted Lines: 
   * Babylon
   * City Terminal Zone
   * Far Rockaway
   * Hempstead
   * Long Beach
   * Montauk
   * Oyster Bay
   * Port Jefferson
   * Port Washington
   * Ronkonkoma
   * West Hempstead